### PR TITLE
172/optimize loading all entities

### DIFF
--- a/mobile-app/lib/backend/Blocs/organization_view/organization_view_bloc.dart
+++ b/mobile-app/lib/backend/Blocs/organization_view/organization_view_bloc.dart
@@ -170,7 +170,6 @@ class OrganizationViewBloc
             appliedIntervention: event.appliedIntervention,
             entity: event.entity));
       } else if (event is AddExecutedSurvey) {
-        // TODO: check AddExecutedSurvey
         bool isCurrentDetailEntity =
             loadedState.currentDetailEntity?.id == event.entity.id;
 
@@ -188,7 +187,8 @@ class OrganizationViewBloc
         toEdit.appliedInterventions[aIIndex].executedSurveys
             .add(event.executedSurvey);
 
-        emit(loadedState.copyWith());
+        emit(loadedState.copyWith(
+            currentDetailEntity: loadedState.currentDetailEntity));
       } else if (event is AddEntity) {
         Entity newEntity = event.entity;
         String id = await EntityRepository.createEntity(newEntity);
@@ -202,7 +202,6 @@ class OrganizationViewBloc
             appBarString: event.entity.name,
             currentDetailEntity: event.entity));
       } else if (event is AddAppliedIntervention) {
-        // TODO: check AddAppliedIntervention
         String id =
             await AppliedInterventionRepository.createAppliedIntervention(
                 event.appliedIntervention, event.entity);
@@ -228,9 +227,9 @@ class OrganizationViewBloc
         if (newCurrentEntity?.id == event.entity.id) {
           newCurrentEntity!.appliedInterventions.add(toAdd);
         }*/
-        emit(loadedState.copyWith());
+        emit(loadedState.copyWith(
+            currentDetailEntity: loadedState.currentDetailEntity));
       } else if (event is UpdateAppliedIntervention) {
-        // TODO: check UpdateAppliedIntervention
         AppliedInterventionRepository.updateAppliedIntervention(
             event.appliedIntervention, event.entity);
         AppliedIntervention toAdd = event.appliedIntervention;
@@ -241,6 +240,7 @@ class OrganizationViewBloc
         toSet.appliedInterventions[aIIndex] = event.appliedIntervention;
 
         emit(loadedState.copyWith(
+            currentDetailEntity: loadedState.currentDetailEntity,
             currentDetailAppliedIntervention:
                 loadedState.currentDetailAppliedIntervention != null
                     ? toAdd
@@ -258,6 +258,7 @@ class OrganizationViewBloc
               ": " +
               event.executedSurvey.survey.name,
           executedSurveyToDisplay: event.executedSurvey,
+          currentDetailEntity: loadedState.currentDetailEntity,
           organizationViewType: OrganizationViewType.EXECUTEDSURVEY,
         ));
       } else if (event is UpdatePic) {
@@ -265,6 +266,7 @@ class OrganizationViewBloc
             organizationViewType: loadedState.organizationViewType,
             appBarString: loadedState.appBarString,
             addEntityPossible: loadedState.addEntityPossible,
+            currentDetailEntity: loadedState.currentDetailEntity,
             currentDetailAppliedIntervention:
                 loadedState.currentDetailAppliedIntervention,
             executedSurveyToDisplay: loadedState.executedSurveyToDisplay));

--- a/mobile-app/lib/backend/Blocs/organization_view/organization_view_events.dart
+++ b/mobile-app/lib/backend/Blocs/organization_view/organization_view_events.dart
@@ -7,8 +7,14 @@ abstract class OrganizationViewEvent {}
 class BackTapEvent extends OrganizationViewEvent {}
 
 class NavigateToDaughterView extends OrganizationViewEvent {
-  String parentID;
-  NavigateToDaughterView(this.parentID);
+  Entity parent;
+  NavigateToDaughterView(this.parent);
+}
+
+class LoadDaughterEntities extends OrganizationViewEvent {
+  Entity? parent;
+  int page;
+  LoadDaughterEntities(this.parent, this.page);
 }
 
 class NavigateToEntityOverview extends OrganizationViewEvent {
@@ -68,8 +74,11 @@ class StartSurvey extends OrganizationViewEvent {
 
 class AddEntity extends OrganizationViewEvent {
   Entity entity;
-  bool isDaughter;
-  AddEntity(this.entity, {this.isDaughter = false});
+  //bool isDaughter;
+  AddEntity(
+    this.entity,
+    /*{this.isDaughter = false}*/
+  );
 }
 
 class UpdateEntity extends OrganizationViewEvent {

--- a/mobile-app/lib/backend/Blocs/organization_view/organization_view_state.dart
+++ b/mobile-app/lib/backend/Blocs/organization_view/organization_view_state.dart
@@ -44,6 +44,9 @@ class EntitiesLoadedOrganizationViewState extends OrganizationViewState {
     print("loaded state newly created");
   }
 
+  /**
+   * Notice: `currentDetailEntity` will be taken exactly like it stands in the arguments
+   */
   EntitiesLoadedOrganizationViewState copyWith(
       {List<Level>? allLevels,
       OrganizationViewType? organizationViewType,

--- a/mobile-app/lib/backend/Blocs/organization_view/organization_view_state.dart
+++ b/mobile-app/lib/backend/Blocs/organization_view/organization_view_state.dart
@@ -1,113 +1,79 @@
 import 'package:mobile_app/backend/callableModels/CallableModels.dart';
-import 'package:string_similarity/string_similarity.dart';
 
 class OrganizationViewState {}
 
 class EntitiesLoadedOrganizationViewState extends OrganizationViewState {
-  final List<Entity> allEntities;
+  final List<Level> allLevels;
   final OrganizationViewType organizationViewType;
   final Entity? currentDetailEntity;
-  final List<Entity> currentListEntities;
   final String appBarString;
   final bool addEntityPossible;
   final AppliedIntervention? currentDetailAppliedIntervention;
   final ExecutedSurvey? executedSurveyToDisplay;
+  final List<LevelContent> levelContentList;
   late final DateTime keyDateTime;
 
-  Entity entityByID(String id) => allEntities.firstWhere((e) => e.id == id);
-
-  List<Entity> entitiesByParentID(String? id) {
-    return List.from(
-        allEntities.where((element) => element.parentEntityID == id));
-  }
-
-  List<Entity> entitiesByName(String query) {
-    List<Entity> toSort = List.from(allEntities);
-    toSort.sort((a, b) {
-      double aEqualness = StringSimilarity.compareTwoStrings(a.name, query);
-      double bEqualness = StringSimilarity.compareTwoStrings(b.name, query);
-      if (aEqualness == bEqualness) {
-        return 0;
-      } else if (aEqualness > bEqualness) {
-        return -1;
-      } else {
-        return 1;
-      }
-    });
-    if (toSort.length > 5) {
-      return toSort.sublist(0, 5);
-    }
-    return toSort;
-  }
-
-  bool hasChildren(String entityID) =>
-      allEntities.any((obj) => obj.parentEntityID == entityID);
-
-  List<Level> getLevelsInOrder() {
-    List<Level> toOrder = [];
-    allEntities.forEach((element) {
-      if (!toOrder.any((l) => l.id == element.level.id)) {
-        toOrder.add(element.level);
-      }
-    });
-    int parentIndex =
-        toOrder.indexWhere((element) => element.parentLevelID == null);
-    List<Level> inOrder = [toOrder.removeAt(parentIndex)];
-    while (toOrder.isNotEmpty) {
-      int removeIndex = toOrder
-          .indexWhere((element) => element.parentLevelID == inOrder.last.id);
-      inOrder.add(toOrder.removeAt(removeIndex));
-    }
-    return inOrder;
+  LevelContent get currentLevelContent {
+    return levelContentList.last;
   }
 
   bool addChildPossible(Entity entity) {
-    List<Level> levelsInOrder = getLevelsInOrder();
+    List<Level> levelsInOrder = allLevels;
     return levelsInOrder.last.id != entity.level.id;
   }
 
   Level getCurrentLevel() {
-    return currentListEntities.first.level;
+    return levelContentList.last.level;
   }
 
   Level? getDaughterLevel(Level level) {
-    return getLevelsInOrder()
-        .firstWhere((element) => element.parentLevelID == level.id);
+    return allLevels.firstWhere((element) => element.parentLevelID == level.id);
   }
 
-  EntitiesLoadedOrganizationViewState(
-      {required this.allEntities,
-      required this.organizationViewType,
-      this.currentDetailEntity,
-      required this.currentListEntities,
-      required this.appBarString,
-      required this.addEntityPossible,
-      this.currentDetailAppliedIntervention,
-      this.executedSurveyToDisplay}) {
+  EntitiesLoadedOrganizationViewState({
+    required this.allLevels,
+    required this.organizationViewType,
+    this.currentDetailEntity,
+    required this.levelContentList,
+    required this.appBarString,
+    required this.addEntityPossible,
+    this.currentDetailAppliedIntervention,
+    this.executedSurveyToDisplay,
+  }) {
     this.keyDateTime = DateTime.now();
     print("loaded state newly created");
   }
 
   EntitiesLoadedOrganizationViewState copyWith(
-      {List<Entity>? allEntities,
+      {List<Level>? allLevels,
       OrganizationViewType? organizationViewType,
       Entity? currentDetailEntity,
-      List<Entity>? currentListEntities,
       String? appBarString,
       bool? addEntityPossible,
       AppliedIntervention? currentDetailAppliedIntervention,
-      ExecutedSurvey? executedSurveyToDisplay}) {
+      ExecutedSurvey? executedSurveyToDisplay,
+      List<LevelContent>? levelContentList}) {
     return EntitiesLoadedOrganizationViewState(
-        allEntities: allEntities ?? this.allEntities,
+        allLevels: allLevels ?? this.allLevels,
         organizationViewType: organizationViewType ?? this.organizationViewType,
-        currentListEntities: currentListEntities ?? this.currentListEntities,
         currentDetailEntity: currentDetailEntity,
         appBarString: appBarString ?? this.appBarString,
         addEntityPossible: addEntityPossible ?? this.addEntityPossible,
         currentDetailAppliedIntervention: currentDetailAppliedIntervention ??
             this.currentDetailAppliedIntervention,
-        executedSurveyToDisplay: executedSurveyToDisplay);
+        executedSurveyToDisplay: executedSurveyToDisplay,
+        levelContentList: levelContentList ?? this.levelContentList);
   }
+}
+
+class LevelContent {
+  Level level;
+  Entity? parentEntity;
+  List<Entity> daughterEntities = [];
+  int page = 0;
+  bool hasMoreToLoad = true;
+
+  LevelContent(this.level, this.parentEntity);
 }
 
 enum OrganizationViewType {

--- a/mobile-app/lib/backend/Blocs/sync/sync_bloc.dart
+++ b/mobile-app/lib/backend/Blocs/sync/sync_bloc.dart
@@ -63,6 +63,7 @@ class SyncBloc extends Bloc<SyncEvent, SyncState> {
   }
 
   void fulfillSync() async {
+    return;
     InternetConnectionType internetConnectionType =
         await StorageRepository.currentInternetConnectionType();
     if (internetConnectionType != InternetConnectionType.WIFI) {

--- a/mobile-app/lib/backend/Blocs/sync/sync_bloc.dart
+++ b/mobile-app/lib/backend/Blocs/sync/sync_bloc.dart
@@ -21,6 +21,7 @@ import 'package:mobile_app/backend/repositories/UserRepository.dart';
 import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/backend/storage/storage_repository.dart';
 import 'package:mobile_app/models/InterventionContentRelation.dart';
+import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class SyncBloc extends Bloc<SyncEvent, SyncState> {
   TaskBloc taskBloc;
@@ -63,7 +64,6 @@ class SyncBloc extends Bloc<SyncEvent, SyncState> {
   }
 
   void fulfillSync() async {
-    return;
     InternetConnectionType internetConnectionType =
         await StorageRepository.currentInternetConnectionType();
     if (internetConnectionType != InternetConnectionType.WIFI) {
@@ -71,17 +71,131 @@ class SyncBloc extends Bloc<SyncEvent, SyncState> {
       return;
     }
     add(StartSyncEvent());
-    List<Future> toWaitData = [
-      EntityRepository.getAllEntities(),
-      taskBloc.taskRepository.getAllTasks(),
-      ContentRepository.getAllRelationsWithPopulatedContentsAndInterventions(),
-    ];
-    List<dynamic> data = await Future.wait(toWaitData);
-    List<Entity> allEntities = data[0] as List<Entity>;
-    List<Task> allTasksToSync = data[1] as List<Task>;
+
+    List<amp.Level> allAmpLevels = await LevelRepository.getAllAmpLevels();
+    List<amp.Entity> allAmpEntities =
+        (await EntityRepository.getAllAmpEntities())
+            .map((e) => e.copyWith(
+                appliedInterventions: [],
+                level: allAmpLevels
+                    .where((element) => element.id == e.entityLevelId)
+                    .first))
+            .toList();
+    List<amp.Intervention> allAmpInterventions = (await InterventionRepository
+            .getAllAmpIntervention())
+        .map((e) => e.copyWith(tags: [], contents: [], levels: [], surveys: []))
+        .toList();
+    List<amp.AppliedIntervention> allAmpAppliedInterventions =
+        (await AppliedInterventionRepository.getAllAmpAppliedInterventions())
+            .where((element) =>
+                element.entityAppliedInterventionsId != null &&
+                allAmpInterventions.any((intervention) =>
+                    intervention.id ==
+                    element.appliedInterventionInterventionId))
+            .toList();
+    List<amp.Survey> allAmpSurveys = (await SurveyRepository.getAllAmpSurveys())
+        .where(
+          (element) => element.intervention != null,
+        )
+        .toList()
+        .map((e) => e.copyWith(
+              tags: [],
+            ))
+        .toList();
+    List<amp.ExecutedSurvey> allAmpExecutedSurveys =
+        await ExecutedSurveyRepository.getAllAmpExecutedSurveys();
+
+    // TODO: check population of surveys with SurveySurveyTagRelations
+
+    // TODO: populate contents, tags, levels of Interventions
+
+    // Populate Intervention and Surveys
+    allAmpInterventions.sort((a, b) => a.id.compareTo(b.id));
+    allAmpSurveys
+        .sort(((a, b) => a.intervention!.id.compareTo(b.intervention!.id)));
+    await populateSortedLists<amp.Intervention, amp.Survey, String>(
+        allAmpInterventions,
+        (p0) => p0.id,
+        allAmpSurveys,
+        (p1) => p1.intervention!.id, (i1, i2) async {
+      allAmpSurveys[i2] = allAmpSurveys[i2].copyWith(
+          intervention: allAmpInterventions[i1]
+              .copyWith(contents: [], tags: [], surveys: [], levels: []));
+
+      allAmpInterventions[i1] = allAmpInterventions[i1].copyWith(
+          surveys: (allAmpInterventions[i1].surveys ?? [])
+            ..add(allAmpSurveys[i2]));
+    });
+
+    // Populate AppliedInterventions with Interventions
+    allAmpAppliedInterventions.sort(((a, b) => a
+        .appliedInterventionInterventionId
+        .compareTo(b.appliedInterventionInterventionId)));
+    await populateSortedLists<amp.Intervention, amp.AppliedIntervention,
+            String>(
+        allAmpInterventions,
+        (p0) => p0.id,
+        allAmpAppliedInterventions,
+        (p1) => p1.appliedInterventionInterventionId, (i1, i2) async {
+      amp.Intervention intervention = allAmpInterventions[i1];
+      amp.User user = await UserRepository.getAmpUserByID(
+          allAmpAppliedInterventions[i2].appliedInterventionWhoDidItId);
+      allAmpAppliedInterventions[i2] = allAmpAppliedInterventions[i2].copyWith(
+          intervention: intervention, whoDidIt: user, executedSurveys: []);
+    });
+
+    // Populate AppliedInterventions with ExecutedSurveys
+    allAmpAppliedInterventions.sort(((a, b) => a.id.compareTo(b.id)));
+    allAmpExecutedSurveys.sort(((a, b) =>
+        a.appliedIntervention.id.compareTo(b.appliedIntervention.id)));
+    await populateSortedLists<amp.AppliedIntervention, amp.ExecutedSurvey,
+            String>(
+        allAmpAppliedInterventions,
+        (p0) => p0.id,
+        allAmpExecutedSurveys,
+        (p1) => p1.appliedIntervention.id, (i1, i2) async {
+      var user = await UserRepository.getAmpUserByID(
+          allAmpExecutedSurveys[i2].executedSurveyWhoExecutedItId);
+
+      amp.Survey survey = allAmpSurveys
+          .where((element) =>
+              element.id == allAmpExecutedSurveys[i2].executedSurveySurveyId)
+          .first;
+      allAmpExecutedSurveys[i2] = allAmpExecutedSurveys[i2].copyWith(
+          appliedIntervention: allAmpAppliedInterventions[i1].copyWith(
+            executedSurveys: [],
+          ),
+          survey: survey,
+          whoExecutedIt: user);
+
+      allAmpAppliedInterventions[i1] = allAmpAppliedInterventions[i1].copyWith(
+          executedSurveys: allAmpAppliedInterventions[i1].executedSurveys
+            ..add(allAmpExecutedSurveys[i2]));
+    });
+
+    // Populate Entities with AppliedInterventions
+    allAmpAppliedInterventions.sort(((a, b) => a.entityAppliedInterventionsId!
+        .compareTo(b.entityAppliedInterventionsId!)));
+    allAmpEntities.sort(((a, b) => a.id.compareTo(b.id)));
+    await populateSortedLists<amp.Entity, amp.AppliedIntervention, String>(
+        allAmpEntities,
+        (p0) => p0.id,
+        allAmpAppliedInterventions,
+        (p1) => p1.entityAppliedInterventionsId!, (i1, i2) async {
+      allAmpEntities[i1] = allAmpEntities[i1].copyWith(
+          appliedInterventions: (allAmpEntities[i1].appliedInterventions ?? [])
+            ..add(allAmpAppliedInterventions[i2]));
+    });
+
+    List<Entity> allEntities = allAmpEntities.map((e) {
+      return Entity.fromAmplifyModel(e);
+    }).toList();
+    List<Level> allLevels = await LevelRepository.getAllLevels();
+    List<Task> allTasksToSync = await taskBloc.taskRepository.getAllTasks();
     List<InterventionContentRelation> allContentRelations =
-        data[2] as List<InterventionContentRelation>;
-    List<Level> allLevels = [];
+        await ContentRepository
+            .getAllRelationsWithPopulatedContentsAndInterventions();
+
     List<Content> allContents = [];
     List<Intervention> allInterventions = [];
     for (InterventionContentRelation interventionContentRelation
@@ -117,6 +231,30 @@ class SyncBloc extends Bloc<SyncEvent, SyncState> {
     syncEntities(allEntities);
     if (userBloc.state.user != null) {
       syncUser(userBloc.state.user!);
+    }
+  }
+
+  Future<void> populateSortedLists<P, Q, R extends Comparable>(
+      List<P> list1,
+      R Function(P) param1,
+      List<Q> list2,
+      R Function(Q) param2,
+      Future<void> Function(int, int) populate) async {
+    int i = 0;
+    int j = 0;
+
+    while (i < list1.length && j < list2.length) {
+      P element1 = list1[i];
+      Q element2 = list2[j];
+
+      if (param1(element1).compareTo(param2(element2)) < 0) {
+        i++;
+      } else if (param1(element1).compareTo(param2(element2)) > 0) {
+        j++;
+      } else {
+        await populate(i, j);
+        j++;
+      }
     }
   }
 

--- a/mobile-app/lib/backend/Blocs/task_form/task_form_cubit.dart
+++ b/mobile-app/lib/backend/Blocs/task_form/task_form_cubit.dart
@@ -14,6 +14,7 @@ import 'package:mobile_app/backend/Blocs/user/user_bloc.dart';
 import 'package:mobile_app/backend/callableModels/CallableModels.dart';
 import 'package:mobile_app/backend/callableModels/localModels/attachment.dart';
 import 'package:mobile_app/backend/callableModels/localModels/image_attachment.dart';
+import 'package:mobile_app/backend/repositories/EntityRepository.dart';
 import 'package:mobile_app/backend/repositories/TaskRepository.dart';
 import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/backend/storage/storage_repository.dart';
@@ -72,9 +73,8 @@ class TaskFormCubit extends Cubit<TaskFormState> {
             deadline: task?.dueDate));
 
   Future<List<Entity>> searchForEntities(String? query) async {
-    return (state.organizationViewBloc.state
-            as EntitiesLoadedOrganizationViewState)
-        .entitiesByName(query ?? "");
+    // TODO: makt it possible to search among all entities
+    return EntityRepository.getEntities(searchByName: query, page: 0);
   }
 
   static TaskFormCubit initialize<T extends TaskFormCubit>(

--- a/mobile-app/lib/backend/repositories/AppliedInterventionRepository.dart
+++ b/mobile-app/lib/backend/repositories/AppliedInterventionRepository.dart
@@ -9,6 +9,16 @@ import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class AppliedInterventionRepository {
   static Future<List<amp.AppliedIntervention>>
+      getAllAmpAppliedInterventions() async {
+    List<amp.AppliedIntervention> appliedIntervention =
+        await Amplify.DataStore.query(
+      amp.AppliedIntervention.classType,
+    );
+
+    return appliedIntervention;
+  }
+
+  static Future<List<amp.AppliedIntervention>>
       getAmpAppliedInterventionsByEntityID(String entityID) async {
     print("applied Interventions by Entity: $entityID");
     List<amp.AppliedIntervention> appliedIntervention =

--- a/mobile-app/lib/backend/repositories/EntityRepository.dart
+++ b/mobile-app/lib/backend/repositories/EntityRepository.dart
@@ -9,6 +9,12 @@ import 'package:mobile_app/models/ModelProvider.dart' as amp;
 class EntityRepository {
   static const int batchSize = 15;
 
+  static Future<List<amp.Entity>> getAllAmpEntities() async {
+    return Amplify.DataStore.query<amp.Entity>(
+      amp.Entity.classType,
+    );
+  }
+
   static Future<List<Entity>> getAllEntities({int? page}) async {
     return getEntities(page: page);
   }

--- a/mobile-app/lib/backend/repositories/EntityRepository.dart
+++ b/mobile-app/lib/backend/repositories/EntityRepository.dart
@@ -7,10 +7,31 @@ import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class EntityRepository {
-  static Future<List<Entity>> getAllEntities() async {
+  static const int batchSize = 15;
+
+  static Future<List<Entity>> getAllEntities({int? page}) async {
+    return getEntities(page: page);
+  }
+
+  static Future<List<Entity>> getEntities(
+      {int? page,
+      bool byParentEntityID = false,
+      String? parentEntityID,
+      String? searchByName}) async {
     List<amp.Entity> allAmpEntities = await Amplify.DataStore.query(
-      amp.Entity.classType,
-    );
+        amp.Entity.classType,
+        where: byParentEntityID && searchByName != null
+            ? amp.Entity.PARENTENTITYID
+                .eq(parentEntityID)
+                .and(amp.Entity.NAME.contains(searchByName))
+            : byParentEntityID
+                ? amp.Entity.PARENTENTITYID.eq(parentEntityID)
+                : searchByName != null
+                    ? amp.Entity.NAME.contains(searchByName)
+                    : null,
+        pagination: page == null
+            ? null
+            : QueryPagination(page: page, limit: batchSize));
     List<amp.Entity> popluatedEntities =
         await _populateMultipleConnections(allAmpEntities);
 

--- a/mobile-app/lib/backend/repositories/ExecutedSurveyRepository.dart
+++ b/mobile-app/lib/backend/repositories/ExecutedSurveyRepository.dart
@@ -8,6 +8,13 @@ import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class ExecutedSurveyRepository {
+  static Future<List<amp.ExecutedSurvey>> getAllAmpExecutedSurveys() async {
+    var results = Amplify.DataStore.query(
+      amp.ExecutedSurvey.classType,
+    );
+    return results;
+  }
+
   static Future<ExecutedSurvey> executedSurveyByID(
       String executedSurveyID) async {
     amp.ExecutedSurvey executedSurvey =

--- a/mobile-app/lib/backend/repositories/InterventionRepository.dart
+++ b/mobile-app/lib/backend/repositories/InterventionRepository.dart
@@ -6,6 +6,13 @@ import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class InterventionRepository {
+  static Future<List<amp.Intervention>> getAllAmpIntervention() async {
+    var interventions = Amplify.DataStore.query(
+      amp.Intervention.classType,
+    );
+    return interventions;
+  }
+
   static Future<amp.Intervention> getAmpInterventionByID(
       String interventionID) async {
     try {

--- a/mobile-app/lib/backend/repositories/LevelRepository.dart
+++ b/mobile-app/lib/backend/repositories/LevelRepository.dart
@@ -5,6 +5,12 @@ import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class LevelRepository {
+  static Future<List<amp.Level>> getAllAmpLevels() async {
+    return Amplify.DataStore.query(
+      amp.Level.classType,
+    );
+  }
+
   static Future<List<Level>> getAllLevels() async {
     List<amp.Level> levels = await Amplify.DataStore.query(
       amp.Level.classType,

--- a/mobile-app/lib/backend/repositories/LevelRepository.dart
+++ b/mobile-app/lib/backend/repositories/LevelRepository.dart
@@ -5,6 +5,33 @@ import 'package:mobile_app/backend/storage/image_synch.dart';
 import 'package:mobile_app/models/ModelProvider.dart' as amp;
 
 class LevelRepository {
+  static Future<List<Level>> getAllLevels() async {
+    List<amp.Level> levels = await Amplify.DataStore.query(
+      amp.Level.classType,
+    );
+
+    List<amp.Level> populated =
+        await Future.wait(levels.map((e) => _populate(e)).toList());
+    List<Level> toOrder =
+        populated.map((e) => Level.fromAmplifyModel(e)).toList();
+
+    // Sort in the ascending order
+    List<Level> result = [];
+    int rootIndex =
+        toOrder.indexWhere((element) => element.parentLevelID == null);
+    result.add(toOrder[rootIndex]);
+    toOrder.removeAt(rootIndex);
+
+    while (toOrder.isNotEmpty) {
+      int childIndex = toOrder
+          .indexWhere((element) => element.parentLevelID == result.last.id);
+      result.add(toOrder[childIndex]);
+      toOrder.removeAt(childIndex);
+    }
+
+    return Future.value(result);
+  }
+
   static Future<amp.Level> getAmpLevelByID(String levelID) async {
     List<amp.Level> levels = await Amplify.DataStore.query(amp.Level.classType,
         where: amp.Level.ID.eq(levelID));

--- a/mobile-app/lib/backend/repositories/SurveyRepository.dart
+++ b/mobile-app/lib/backend/repositories/SurveyRepository.dart
@@ -11,6 +11,13 @@ class SurveyRepository {
     return Survey.fromAmplifyModel(survey);
   }
 
+  static Future<List<amp.Survey>> getAllAmpSurveys() async {
+    List<amp.Survey> results = await Amplify.DataStore.query(
+      amp.Survey.classType,
+    );
+    return results;
+  }
+
   static Future<amp.Survey> getAmpSurveyByID(String surveyID) async {
     List<amp.Survey> results = await Amplify.DataStore.query(
         amp.Survey.classType,
@@ -51,6 +58,13 @@ class SurveyRepository {
       {amp.Intervention? intervention}) {
     return Future.wait(
         List.generate(surveys.length, (index) => _populate(surveys[index])));
+  }
+
+  static Future<List<amp.SurveySurveyTagRelation>>
+      getAllSurveySurveyTagRelationsBySurvey() async {
+    return Amplify.DataStore.query(
+      amp.SurveySurveyTagRelation.classType,
+    );
   }
 
   static Future<List<amp.SurveySurveyTagRelation>>

--- a/mobile-app/pubspec.lock
+++ b/mobile-app/pubspec.lock
@@ -457,6 +457,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.4.0"
+  lazy_load_scrollview:
+    dependency: "direct main"
+    description:
+      name: lazy_load_scrollview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   lints:
     dependency: transitive
     description:
@@ -478,7 +485,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   material_design_icons_flutter:
     dependency: "direct main"
     description:
@@ -735,7 +748,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   hive: ^2.1.0
   connectivity_plus: ^2.2.1
   flutter_rating_bar: ^4.0.0
+  lazy_load_scrollview: ^1.3.0
 
 
 dev_dependencies:


### PR DESCRIPTION
**What is done:**
- Lazy loading of the entities on the organization view page
- Amount of requests was significantly reduced, when loading all data for synchronising attachments. The synchronisation accelerated about 7.5 times on a dev environment.

**Next steps:**
1. Check the possibility to work with isolates for catching data
2. Populate all models directly with callable models on repositories